### PR TITLE
fix: clean unused code and regex

### DIFF
--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -1,10 +1,10 @@
 import { Link } from "react-router-dom";
-import { motion } from "framer-motion";
+import { motion as Motion } from "framer-motion";
 import { formatDate } from "../utils/formatDate";
 
 export default function ArticleCard({ a }) {
   return (
-    <motion.article
+    <Motion.article
       layout
       className="card"
       initial={{ opacity: 0, y: 10 }}
@@ -32,6 +32,6 @@ export default function ArticleCard({ a }) {
           <p>{a.excerpt}</p>
         </div>
       </Link>
-    </motion.article>
+    </Motion.article>
   );
 }

--- a/src/components/PageFade.jsx
+++ b/src/components/PageFade.jsx
@@ -1,15 +1,15 @@
 // src/components/PageFade.jsx
-import { motion } from "framer-motion";
+import { motion as Motion } from "framer-motion";
 
 export default function PageFade({ children }) {
   return (
-    <motion.div
+    <Motion.div
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -6 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
     >
       {children}
-    </motion.div>
+    </Motion.div>
   );
 }

--- a/src/utils/readTime.js
+++ b/src/utils/readTime.js
@@ -2,7 +2,8 @@
 export function readTime(md = "") {
   const text = md
     .replace(/```[\s\S]*?```/g, "")  // blocs code
-    .replace(/[#>*_\-\[\]\(\)`~]/g, ""); // ponctuation markdown
+    .replace(/[#>*_`~-]/g, "") // ponctuation markdown
+    .replace(/\[|\]|\(|\)/g, "");
   const words = text.trim().split(/\s+/).filter(Boolean).length;
   const mins = Math.max(1, Math.round(words / 200));
   return `${mins} min`;


### PR DESCRIPTION
## Summary
- remove unused motion imports by aliasing to `Motion`
- simplify markdown read time regex

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76104171883228e37a9670fa766cd