### PR TITLE
fix: resolve LazyImage import path

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -5,6 +5,7 @@ import LazyArticleCard from "../components/LazyArticleCard";
 import { articles } from "../data/articles";
 import Seo from "../components/Seo";
 import Countdown from "../components/Countdown";
+import LazyImage from "../components/LazyImage";
 
 export default function HomePage() {
   const [q, setQ] = useState("");


### PR DESCRIPTION
## Summary
- fix LazyImage import path in home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9b83e1f2c8322af6c5fd11cf1de0b