### PR TITLE
feat: add thumbnails to recent articles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -145,8 +145,12 @@ a { color: inherit; text-decoration: none; }
 
 /* Articles récents */
 .recent { list-style: none; padding: 0; margin: 12px 0 0; display: grid; gap: 10px; }
-.recent a { color: #ddd; }
-.recent a:hover { color: #fff; }
+.recent-item { display: flex; align-items: center; gap: 12px; color: #ddd; }
+.recent-item:hover { color: #fff; }
+.recent-thumb { width: 80px; aspect-ratio: 16/9; border-radius: 8px; overflow: hidden; flex-shrink: 0; }
+.recent-thumb > div { height: 100%; }
+.recent-thumb img { width: 100%; height: 100%; object-fit: cover; transition: transform .3s ease; display: block; }
+.recent-item:hover .recent-thumb img { transform: scale(1.1); }
 
 /* Page article */
 .article .cover { width: 100%; border-radius: 12px; border: 1px solid #222; margin: 8px 0 16px; }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -5,6 +5,7 @@ import LazyArticleCard from "../components/LazyArticleCard";
 import { articles } from "../data/articles";
 import Seo from "../components/Seo";
 import Countdown from "../components/Countdown";
+import LazyImage from "../components/LazyImage";
 
 export default function HomePage() {
   const [q, setQ] = useState("");
@@ -118,10 +119,17 @@ export default function HomePage() {
             <ul className="recent">
               {recents.map((a) => (
                 <li key={a.id}>
-                  <Link to={`/article/${a.slug}`}>{a.title}</Link>
-                  <div className="muted" style={{ fontSize: 12 }}>
-                    {a.category}
-                  </div>
+                  <Link to={`/article/${a.slug}`} className="recent-item">
+                    <div className="recent-thumb">
+                      <LazyImage src={a.cover} alt="" />
+                    </div>
+                    <div className="recent-content">
+                      <span className="recent-title">{a.title}</span>
+                      <div className="muted" style={{ fontSize: 12 }}>
+                        {a.category}
+                      </div>
+                    </div>
+                  </Link>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- show thumbnail images for recent articles with hover zoom effect
- fix LazyImage import path in home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b83e1f2c8322af6c5fd11cf1de0b